### PR TITLE
Feature/help menu key

### DIFF
--- a/dooit/ui/tui.py
+++ b/dooit/ui/tui.py
@@ -25,6 +25,9 @@ class Doit(App):
         for widget in self.navbar_box:
             widget.toggle_highlight()
 
+    async def on_load(self) -> None:
+        await self.bind("q", "quit", "Quit")
+
     async def action_quit(self) -> None:
         await self.on_key(events.Key(self, "escape"))  # incase of empty todo
         await super().action_quit()

--- a/dooit/ui/tui.py
+++ b/dooit/ui/tui.py
@@ -26,7 +26,7 @@ class Doit(App):
             widget.toggle_highlight()
 
     async def on_load(self) -> None:
-        await self.bind("q", "quit", "Quit")
+        await self.bind("ctrl+q", "quit", "Quit")
 
     async def action_quit(self) -> None:
         await self.on_key(events.Key(self, "escape"))  # incase of empty todo

--- a/dooit/ui/tui.py
+++ b/dooit/ui/tui.py
@@ -286,7 +286,7 @@ class Doit(App):
                 await self.help_menu.key_end()
 
     async def on_key(self, event: events.Key) -> None:
-        if event.key == "ctrl+p" or (event.key == "escape" and self.help):
+        if (event.key == "ctrl+p") or (event.key == "escape" and self.help) or event.key == "?":
             await self.toggle_help()
             return
 

--- a/dooit/ui/widgets/help_menu.py
+++ b/dooit/ui/widgets/help_menu.py
@@ -126,7 +126,7 @@ Documentation below will walk you through the controls:
 THANKS = f"{colored('Thanks for using dooit :heart:', 'yellow')}"
 AUTHOR = f"{colored('--kraanzu', 'orchid')}{NL * 2}{seperator}{NL}"
 
-OUTRO = f"Press {colored('escape', 'green')} or {colored('ctrl+p', 'green')} to exit help menu"
+OUTRO = f"Press {colored('escape', 'green')}, {colored('ctrl+p', 'green')}, or {colored('?', 'green')} to exit help menu"
 
 # ---------------- X -------------------------
 

--- a/dooit/ui/widgets/help_menu.py
+++ b/dooit/ui/widgets/help_menu.py
@@ -119,7 +119,7 @@ HEADER = f"""
 
 BODY = f""" {colored(f'Dooit is build to be used from the keyboard,{NL} but mouse can also be used to navigate', 'green')}
 
-Documentation below will wak you through the controls:
+Documentation below will walk you through the controls:
 {seperator}
 """
 

--- a/dooit/ui/widgets/help_menu.py
+++ b/dooit/ui/widgets/help_menu.py
@@ -73,6 +73,7 @@ NORMAL_KB = {
     "/": "Start Search Mode ⃰ ⃰ ",
     "enter": "Select topic ⃰ ",
     "tab": "Move focus to Menu ⃰ ⃰ ",
+    "q": "Quit the Application",
 }
 
 NORMAL_NB = [

--- a/dooit/ui/widgets/todo_list.py
+++ b/dooit/ui/widgets/todo_list.py
@@ -274,7 +274,7 @@ class TodoList(NestedListEdit):
                         self.highlighted_node.data.due.value = self.prev_date
                     else:
                         await self.post_message(
-                            Notify(self, message="You due date was updated")
+                            Notify(self, message="Your due date was updated")
                         )
 
                 else:


### PR DESCRIPTION
# Description
This pull request aims to implement some additional keybinds for opening/closing the help menu and quitting the app. It also corrects some typos found in the codebase.

These are minor changes that integrate keymappings commonly found in other TUI applications. The keybinds are obviously preference. Prior to these changes, the `q` and `?` keys were unmapped, so I figured implementing binds for them was okay -- not sure if there was unimplemented functionality you'd want to map either of those two keys.

## Changes
* Press `q` from any menu to close the app.
* Press `?` to toggle the help menu.
* `on_load` function implemented for the `Doit` class. Sets up the `q` keybind for quitting the app.

## Side Notes
Very useful application in general! I am excited to utilize this for school.