### PR TITLE
Use $XDG_CONFIG_HOME if set

### DIFF
--- a/dooit/utils/config.py
+++ b/dooit/utils/config.py
@@ -1,8 +1,9 @@
 import yaml
 from pathlib import Path
+from os import environ
 
 HOME = Path.home()
-XDG_CONFIG = HOME / ".config"
+XDG_CONFIG = Path(environ["XDG_CONFIG_HOME"] or HOME / ".config")
 CONFIG = XDG_CONFIG / "dooit" / "config.yaml"
 
 SAMPLE = Path(__file__).parent.absolute() / "example_config.yaml"

--- a/dooit/utils/config.py
+++ b/dooit/utils/config.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from os import environ
 
 HOME = Path.home()
-XDG_CONFIG = Path(environ["XDG_CONFIG_HOME"] or HOME / ".config")
+XDG_CONFIG = Path(environ.get("XDG_CONFIG_HOME") or HOME / ".config")
 CONFIG = XDG_CONFIG / "dooit" / "config.yaml"
 
 SAMPLE = Path(__file__).parent.absolute() / "example_config.yaml"


### PR DESCRIPTION
The [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) requires using `$XDG_CONFIG_HOME` if it is set, and falling back to `$HOME/.config` if not.

This PR makes dooit conform to the said specification.