### PR TITLE
refactor: Simplify if-else logic, cleanup and other refactors

### DIFF
--- a/dooit/ui/tui.py
+++ b/dooit/ui/tui.py
@@ -152,20 +152,7 @@ class Doit(App):
 
             self.grid.place(**placements)
 
-        borders = []
-        for i in range(2):
-            borders.append(
-                [
-                    f"middle{2 * i}",
-                    f"top_connector{2 * i}",
-                    f"top{i}",
-                    f"top_connector{2 * i + 1}",
-                    f"middle{2 * i + 1}",
-                    f"bottom_connector{2 * i + 1}",
-                    f"bottom{i}",
-                    f"bottom_connector{2 * i}",
-                ]
-            )
+        borders = [[f"middle{2 * i}", f"top_connector{2 * i}", f"top{i}", f"top_connector{2 * i + 1}", f"middle{2 * i + 1}", f"bottom_connector{2 * i + 1}", f"bottom{i}", f"bottom_connector{2 * i}",] for i in range(2)]
 
         self.navbar_box = self._make_box(borders[0])
         self.todos_box = self._make_box(borders[1])

--- a/dooit/ui/tui.py
+++ b/dooit/ui/tui.py
@@ -181,7 +181,7 @@ class Doit(App):
             self.grid.add_areas(**areas)
 
         # WIDGET SPACES
-        middle_areas = dict()
+        middle_areas = {}
         if not self.show_header:
             middle_areas["0b"] = "0,a-start|b-end"
             middle_areas["1b"] = "1,a-start|b-end"

--- a/dooit/ui/widgets/border.py
+++ b/dooit/ui/widgets/border.py
@@ -67,11 +67,9 @@ class Connector1(Border):
         super().__init__(item="┏")
 
     def render(self) -> RenderableType:
-        width = self.size.width - 1
-        height = self.size.height - 1
-        if width:
+        if width := self.size.width - 1:
             self.item += "━" * width
-        if height:
+        if height := self.size.height - 1:
             self.item += "\n┃" * height
 
         style = "bold blue" if self.highlight else "dim white"
@@ -87,11 +85,9 @@ class Connector2(Border):
         super().__init__(item="┓")
 
     def render(self) -> RenderableType:
-        width = self.size.width - 2
-        height = self.size.height - 1
-        if width:
+        if width := self.size.width - 2:
             self.item = "━" * width + self.item
-        if height:
+        if height := self.size.height - 1:
             self.item += "\n┃" * height
 
         style = "bold blue" if self.highlight else "dim white"
@@ -107,11 +103,9 @@ class Connector3(Border):
         super().__init__(item="┗")
 
     def render(self) -> RenderableType:
-        width = self.size.width - 1
-        height = self.size.height - 1
-        if width:
+        if width := self.size.width - 1:
             self.item += "━" * width
-        if height:
+        if height := self.size.height - 1:
             self.item += "\n┃" * height
 
         style = "bold blue" if self.highlight else "dim white"
@@ -127,11 +121,9 @@ class Connector4(Border):
         super().__init__(item="┛")
 
     def render(self) -> RenderableType:
-        width = self.size.width - 2
-        height = self.size.height - 1
-        if width:
+        if width := self.size.width - 2:
             self.item = "━" * width + self.item
-        if height:
+        if height := self.size.height - 1:
             self.item += "\n┃" * height
 
         style = "bold blue" if self.highlight else "dim white"

--- a/dooit/ui/widgets/entry.py
+++ b/dooit/ui/widgets/entry.py
@@ -10,9 +10,7 @@ def generate_uuid() -> str:
     """
     Generates a unique id for entries
     """
-    uuid = ""
-    for _ in range(32):
-        uuid += choice(chars)
+    uuid = "".join(choice(chars) for _ in range(32))
     return uuid
 
 

--- a/dooit/ui/widgets/help_menu.py
+++ b/dooit/ui/widgets/help_menu.py
@@ -33,12 +33,8 @@ def generate_kb_table(
 
     table.add_row(Text.from_markup(f" [r green] {topic} [/r green]"), "", "", "")
     for cmd, help in kb.items():
-        table.add_row(
-            "",
-            (Text.from_markup(colored(cmd, "blue"))),
-            "",
-            (Text.from_markup(colored("  " + help, "magenta")) + NL),
-        )
+        table.add_row("", Text.from_markup(colored(cmd, "blue")), "", Text.from_markup(colored(f"  {help}", "magenta")) + NL)
+
 
     if notes:
         notes = [f"{colored('', 'd yellow')} {i}" for i in notes]

--- a/dooit/ui/widgets/navbar.py
+++ b/dooit/ui/widgets/navbar.py
@@ -195,12 +195,7 @@ class Navbar(NestedListEdit):
         Adds sibling for the currently selected node
         """
 
-        parent = self.highlighted_node.parent
-
-        if not parent:
-            await self.add_child()
-            return
-        else:
+        if parent := self.highlighted_node.parent:
             children = parent.children
             tree = parent.tree.children
 
@@ -213,6 +208,9 @@ class Navbar(NestedListEdit):
             while self.highlighted != id:
                 await self.cursor_down()
 
+        else:
+            await self.add_child()
+            return
         await self.focus_node()
         self.refresh()
 

--- a/dooit/ui/widgets/navbar.py
+++ b/dooit/ui/widgets/navbar.py
@@ -105,14 +105,8 @@ class Navbar(NestedListEdit):
             > 1
         ):
 
-            await self.post_message(
-                Notify(
-                    self,
-                    f"{WARNING}: Duplicate sibling topic!"
-                    if not self.warn
-                    else "Topic Deleted!",
-                )
-            )
+            await self.post_message(Notify(self, "Topic Deleted!" if self.warn else f"{WARNING}: Duplicate sibling topic!"))
+
             return False
 
         return True

--- a/dooit/ui/widgets/navbar.py
+++ b/dooit/ui/widgets/navbar.py
@@ -239,7 +239,7 @@ class Navbar(NestedListEdit):
             icon = icons["single_topic"]
 
         # Padding adjustment
-        label.plain = f" {icon} " + label.plain + " "
+        label.plain = f" {icon} {label.plain} "
         label.pad_right(self.size.width)
 
         if node.id == self.highlighted:

--- a/dooit/ui/widgets/simple_input.py
+++ b/dooit/ui/widgets/simple_input.py
@@ -110,11 +110,10 @@ class SimpleInput(Widget):
 
         if self.has_focus:
             text = self._render_text_with_cursor()
+        elif len(self.value) == 0:
+            return self.render_panel(self.placeholder)
         else:
-            if len(self.value) == 0:
-                return self.render_panel(self.placeholder)
-            else:
-                text = self.value
+            text = self.value
 
         formatted_text = Text.from_markup(self._format_text(text))
         return self.render_panel(formatted_text)

--- a/dooit/ui/widgets/simple_input.py
+++ b/dooit/ui/widgets/simple_input.py
@@ -170,12 +170,11 @@ class SimpleInput(Widget):
         self.refresh()
 
     def _is_allowed(self, text: str) -> bool:
-        if self.list[0] == "whitelist":
-            for letter in text:
+        for letter in text:
+            if self.list[0] == "whitelist":
                 if letter not in self.list[1]:
                     return False
-        else:
-            for letter in text:
+            else:
                 if letter in self.list[1]:
                     return False
 

--- a/dooit/ui/widgets/simple_input.py
+++ b/dooit/ui/widgets/simple_input.py
@@ -171,13 +171,8 @@ class SimpleInput(Widget):
 
     def _is_allowed(self, text: str) -> bool:
         for letter in text:
-            if self.list[0] == "whitelist":
-                if letter not in self.list[1]:
-                    return False
-            else:
-                if letter in self.list[1]:
-                    return False
-
+            if self.list[0] == "whitelist" and letter not in self.list[1] or self.list[0] != "whitelist" and letter in self.list[1]:
+                return False
         return True
 
     async def _insert_text(self, text: str | None = None) -> None:

--- a/dooit/ui/widgets/todo_list.py
+++ b/dooit/ui/widgets/todo_list.py
@@ -169,17 +169,17 @@ class TodoList(NestedListEdit):
     async def unfocus_node(self) -> None:
 
         ok = await self.check_node()
-        if not ok:
-            if self.warn:
-                await self.remove_node()
-                await self.post_message(ChangeStatus(self, "NORMAL"))
-                await super().unfocus_node()
-            else:
-                self.warn = True
-                return
-        else:
+        if ok:
             await self.post_message(ChangeStatus(self, "NORMAL"))
             await super().unfocus_node()
+
+        elif self.warn:
+            await self.remove_node()
+            await self.post_message(ChangeStatus(self, "NORMAL"))
+            await super().unfocus_node()
+        else:
+            self.warn = True
+            return
 
     async def modify_due_status(self, status: str) -> None:
         node = self.highlighted_node
@@ -414,7 +414,12 @@ class TodoList(NestedListEdit):
             self.refresh(layout=True)
 
     async def add_sibling(self) -> None:
-        if parent := self.highlighted_node.parent:
+        parent = self.highlighted_node.parent
+
+        if not parent:
+            await self.add_child()
+            return
+        else:
             children = parent.children
             tree = parent.tree.children
 
@@ -428,9 +433,6 @@ class TodoList(NestedListEdit):
             while self.highlighted != id:
                 await self.cursor_down()
 
-        else:
-            await self.add_child()
-            return
         await self.focus_node()
         self.refresh()
 

--- a/dooit/ui/widgets/todo_list.py
+++ b/dooit/ui/widgets/todo_list.py
@@ -414,12 +414,7 @@ class TodoList(NestedListEdit):
             self.refresh(layout=True)
 
     async def add_sibling(self) -> None:
-        parent = self.highlighted_node.parent
-
-        if not parent:
-            await self.add_child()
-            return
-        else:
+        if parent := self.highlighted_node.parent:
             children = parent.children
             tree = parent.tree.children
 
@@ -433,6 +428,9 @@ class TodoList(NestedListEdit):
             while self.highlighted != id:
                 await self.cursor_down()
 
+        else:
+            await self.add_child()
+            return
         await self.focus_node()
         self.refresh()
 

--- a/dooit/utils/parser.py
+++ b/dooit/utils/parser.py
@@ -52,7 +52,7 @@ class Parser:
             return x
 
         with open(self.todo_yaml, "r") as f:
-            todos = yaml.safe_load(f) or dict()
+            todos = yaml.safe_load(f) or {}
 
         navbar = Navbar()
         todo_tree = {}
@@ -179,7 +179,4 @@ class Parser:
         self.todo_yaml = dooit_data / "todo.yaml"
         if not Path.is_file(self.todo_yaml):
             with open(self.todo_yaml, "w") as f:
-                yaml.safe_dump(
-                    dict(),
-                    f,
-                )
+                yaml.safe_dump({}, f)

--- a/dooit/utils/parser.py
+++ b/dooit/utils/parser.py
@@ -140,17 +140,13 @@ class Parser:
 
     # DEPRECATED: will be removed in v0.3.0
     def fetch_usable_info_todo(self, todo: TodoList) -> list:
-        x = []
-        for i in todo.root.children:
-            x.append([i.data.encode(), [j.data.encode() for j in i.children]])
+        x = [[i.data.encode(), [j.data.encode() for j in i.children]] for i in todo.root.children]
 
         return x
 
     # DEPRECATED: will be removed in v0.3.0
     def fetch_usable_info_topic(self, topic: Navbar) -> list:
-        x = []
-        for i in topic.root.children:
-            x.append([i.data.value, [j.data.value for j in i.children]])
+        x = [[i.data.value, [j.data.value for j in i.children]] for i in topic.root.children]
 
         return x
 


### PR DESCRIPTION
WIP PR. 

The purpose of the PR is to cleanup things, get some easy speed wins, and make if-else logic easier to understand.
Just want some of your input before I mark this as not a draft.
1.  I see some instances where variables are immediately returned after variable creation. Would it be alright to refactor these to just return immediately? 
ex:
```python
def foo(a):
	b = a ** 2
	return b
```
can be turned into:
```python
def foo(a):
	return a ** 2
```
2. Swap if-else statements with if-else expressions:
For.example:
```python
def _set_view(self):
        if self.box:
            self.width = self.size.width - 4
        else:
            self.width = self.size.width
```
to:
```python
def _set_view(self):
        self.width = self.size.width - 4 if self.box else self.size.width
```