### PR TITLE
fix: os.getlogin() failed to startup in wsl.

### DIFF
--- a/dooit/utils/default_config.py
+++ b/dooit/utils/default_config.py
@@ -26,7 +26,13 @@ def get_clock() -> Text:
 
 
 def get_username():
-    return Text(f" {os.getlogin()} ", "r " + blue)
+    try:
+        username = os.getlogin()
+    except OSError:
+        uid = os.getuid()
+        import pwd
+        username = pwd.getpwuid(uid).pw_name
+    return Text(f" {username} ", "r " + blue)
 
 
 #################################


### PR DESCRIPTION
Met `OSError: [Errno 2] No such file or directory` when calling the `os.getlogin()` in WSL.
Reference:
https://github.com/initstring/uptux/issues/1
