### PR TITLE
add support for all printable unicode characters

### DIFF
--- a/dooit/ui/screens/base.py
+++ b/dooit/ui/screens/base.py
@@ -7,15 +7,16 @@ class BaseScreen(Screen):
     Base screen with function to resolve `Key` event to str
     """
 
-    PRINTABLE = (
-        "0123456789"
-        + "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        + "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ "
+    SPACE_CHARACTERS = (
+        "\u0020\u00a0\u1680\u202f\u205f\u3000"
+        "\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b"
     )
 
     def resolve_key(self, event: events.Key) -> str:
-        return (
-            event.character
-            if (event.character and (event.character in self.PRINTABLE))
-            else event.key
-        )
+        if not event.character:
+            return event.key
+
+        if event.is_printable or event.character in self.SPACE_CHARACTERS:
+            return event.character
+
+        return event.key

--- a/dooit/ui/screens/index.py
+++ b/dooit/ui/screens/index.py
@@ -56,6 +56,9 @@ class MainScreen(BaseScreen):
         event.stop()
 
         key = self.resolve_key(event)
+        await self.send_keypress(key)
+    
+    async def send_keypress(self, key: str):
         if self.bar.status == "SEARCH":
             return await self.query_one(Searcher).keypress(key)
 
@@ -83,6 +86,13 @@ class MainScreen(BaseScreen):
     async def mount_dashboard(self) -> None:
         await self.clear_right()
         await self.mount(EmptyWidget(), after=self.query_one(WorkspaceTree))
+    
+    @on(events.Paste)
+    async def paste_texts(self, event: events.Paste) -> None:
+        event.prevent_default()
+        event.stop()
+        if not event.text: return
+        await self.send_keypress(f'events.Paste:{event.text}')
 
     @on(ApplySort)
     async def apply_sort(self, event: ApplySort) -> None:

--- a/dooit/ui/widgets/simple_input.py
+++ b/dooit/ui/widgets/simple_input.py
@@ -193,9 +193,6 @@ class Input(Widget):
         """
         Handles Keypresses
         """
-        if key == "space":
-            key = " "
-
         if key == "enter":
             await self.stop_edit()
 
@@ -245,7 +242,7 @@ class Input(Widget):
             except Exception:
                 return
 
-        if len(key) == 1:
+        elif len(key) == 1:
             await self._insert_text(key)
 
         self.refresh(layout=True)

--- a/dooit/ui/widgets/simple_input.py
+++ b/dooit/ui/widgets/simple_input.py
@@ -236,11 +236,13 @@ class Input(Widget):
             await self._insert_text("\t")
 
         # COPY-PASTA
-        elif key == "ctrl+v":
-            try:
-                await self._insert_text()
-            except Exception:
-                return
+        # elif key == "ctrl+v":
+        #     try:
+        #         await self._insert_text()
+        #     except Exception:
+        #         return
+        elif key.startswith('events.Paste:'):
+            await self._insert_text(key[13:])
 
         elif len(key) == 1:
             await self._insert_text(key)


### PR DESCRIPTION
This PR add support for more unicode characters by accepting all characters that is `event.Key.is_printable`, and also add some exceptions for some space characters such as `0xa0(nbsp)`, `\u3000`(half-width space that often used in CJK texts) etc.