### PR TITLE
Misc bugfixes

### DIFF
--- a/dooit/api/todo.py
+++ b/dooit/api/todo.py
@@ -157,6 +157,13 @@ class Todo(Model):
         self.fill_from_data(data[0], overwrite_uuid)
         if len(data) > 1:
             for i in data[1]:
+                # Skips todos with no description and no children
+                if len(i) == 1 and not i[0]['description']:
+                    continue
+                # Don't skip the todo as the children might have data that would be lost otherwise
+                elif len(i) > 1 and not i[0]['description']:
+                    i[0]['description'] = '<Empty>'
+
                 child_todo = self.add_child(kind="todo", index=len(self.todos))
                 child_todo.from_data(i, overwrite_uuid)
 

--- a/dooit/ui/widgets/inputs.py
+++ b/dooit/ui/widgets/inputs.py
@@ -146,7 +146,7 @@ class Urgency(SimpleInput):
             color = GREEN
         elif urgency == 2:
             color = YELLOW
-        elif urgency == 2:
+        elif urgency == 3:
             color = ORANGE
         else:
             color = RED

--- a/dooit/ui/widgets/tree.py
+++ b/dooit/ui/widgets/tree.py
@@ -212,7 +212,7 @@ class Tree(KeyWidget, Widget):
     async def notify(self, message: str) -> None:
         self.post_message(Notify(message))
 
-    def next_node(self) -> Optional[WidgetType]:
+    def next_node(self, is_sibling=False) -> Optional[WidgetType]:
         nodes = self.visible_nodes
         if not nodes:
             return
@@ -224,7 +224,17 @@ class Tree(KeyWidget, Widget):
         if idx == len(nodes) - 1:
             return
 
-        return nodes[idx + 1]
+        next_node = nodes[idx + 1]
+
+        while is_sibling:
+            try:
+                next_node = nodes[idx + 1]
+            except IndexError:
+                return None
+            if next_node in self.current.siblings:
+                return next_node
+            idx += 1
+        return next_node
 
     def prev_node(self) -> Optional[WidgetType]:
         nodes = self.visible_nodes
@@ -321,7 +331,9 @@ class Tree(KeyWidget, Widget):
 
         widget = self.current
 
-        if node := self.next_node():
+        # We only want to get sibling and not children, otherwise selecting the new
+        # self.current will crash as it was deleted with its parent
+        if node := self.next_node(is_sibling=True):
             self.current = node
         elif node := self.prev_node():
             self.current = node

--- a/dooit/ui/widgets/tree.py
+++ b/dooit/ui/widgets/tree.py
@@ -312,6 +312,10 @@ class Tree(KeyWidget, Widget):
             if type_ == "child"
             else self.node.add_sibling()
         )
+        # Neccessary to call this after node creation,
+        # otherwise the parent node won't show the child_hint until the program
+        # is restarted or the node gets collapsed and uncollapsed
+        await self.current.refresh_value()
 
         widget = self.WidgetType(new_node)
         if type_ == "sibling":


### PR DESCRIPTION
Fixes the following:
- Urgency 3 had the wrong color
- Deleting a expanded todo/workspace with a child crashes
- When creating a child node, the child_hint was not shown until the parent was force redrawn somehow (application restart, closing and expanding the parent of the parent)
- Creating a child of a todo and quitting with an empty description would persists the todo without a description after restarts