### PR TITLE
Make module executable

### DIFF
--- a/dooit/__init__.py
+++ b/dooit/__init__.py
@@ -1,15 +1,1 @@
-import argparse
-from importlib.metadata import version
 from dooit.ui.tui import Dooit
-
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-v", "--version", help="Show version", action="store_true")
-    args = parser.parse_args()
-
-    if args.version:
-        ver = version("dooit")
-        print(f"dooit - {ver}")
-    else:
-        Dooit().run()

--- a/dooit/__init__.py
+++ b/dooit/__init__.py
@@ -1,1 +1,0 @@
-from dooit.ui.tui import Dooit

--- a/dooit/__main__.py
+++ b/dooit/__main__.py
@@ -15,5 +15,5 @@ def main():
         Dooit().run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/dooit/__main__.py
+++ b/dooit/__main__.py
@@ -1,0 +1,19 @@
+import argparse
+from importlib.metadata import version
+from dooit.ui.tui import Dooit
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v", "--version", help="Show version", action="store_true")
+    args = parser.parse_args()
+
+    if args.version:
+        ver = version("dooit")
+        print(f"dooit - {ver}")
+    else:
+        Dooit().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/dooit/ui/widgets/simple_input.py
+++ b/dooit/ui/widgets/simple_input.py
@@ -241,7 +241,7 @@ class Input(Widget):
         #         await self._insert_text()
         #     except Exception:
         #         return
-        elif key.startswith('events.Paste:'):
+        elif key.startswith("events.Paste:"):
             await self._insert_text(key[13:])
 
         elif len(key) == 1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,4 +29,4 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
-dooit = 'dooit.__init__:main'
+dooit = 'dooit.__main__:main'


### PR DESCRIPTION
This moves the main method to `__main__` to make dooit executable with `python -m dooit` which is a bit more convential for python CLI applications