### PR TITLE
main.py: dont import tui for version check

### DIFF
--- a/dooit/__main__.py
+++ b/dooit/__main__.py
@@ -1,6 +1,5 @@
 import argparse
 from importlib.metadata import version
-from dooit.ui.tui import Dooit
 
 
 def main():
@@ -12,6 +11,7 @@ def main():
         ver = version("dooit")
         print(f"dooit - {ver}")
     else:
+        from dooit.ui.tui import Dooit
         Dooit().run()
 
 


### PR DESCRIPTION
Short cut tui import for quicker version check with less unexpected side effects. Follow up to https://github.com/NixOS/nixpkgs/pull/345234#issuecomment-2384060551

EDIT: maybe makes sense to leave this alone until proper pytests are in place to validate program functionality so we can still use the version check to validate the program. 